### PR TITLE
Notes and Changes

### DIFF
--- a/Sdk/MoyasarSdk/Helpers/CreditCardFormatter.swift
+++ b/Sdk/MoyasarSdk/Helpers/CreditCardFormatter.swift
@@ -60,7 +60,7 @@ final class CreditCardFormatter {
         if cleaned.count > 2 {
             let month = cleaned.prefix(2)
             let year = cleaned.suffix(from: cleaned.index(cleaned.startIndex, offsetBy: 2))
-            return "\(month)/\(year)"
+            return "\(month) / \(year)"
         }
         return cleaned
     }

--- a/Sdk/MoyasarSdk/Models/CreditCardViewModel.swift
+++ b/Sdk/MoyasarSdk/Models/CreditCardViewModel.swift
@@ -209,8 +209,12 @@ public class CreditCardViewModel: ObservableObject {
     }
     
     func handleError(_ error: Error) {
-        let callbackError = MoyasarError.unexpectedError("Credit Card payment request failed: \(error.localizedDescription)")
-        resultCallback(.failed(callbackError))
+        if let moyasarError = error as? MoyasarError {
+            resultCallback(.failed(moyasarError))
+        } else {
+            let callbackError = MoyasarError.unexpectedError("Credit Card payment request failed: \(error.localizedDescription)")
+            resultCallback(.failed(callbackError))
+        }
     }
 }
 

--- a/Sdk/MoyasarSdk/Services/PaymentServices/PaymentServices.swift
+++ b/Sdk/MoyasarSdk/Services/PaymentServices/PaymentServices.swift
@@ -72,6 +72,10 @@ final public class PaymentService {
             
             return try decoder.decode(T.self, from: data)
         } catch {
+            if let moyasarError = error as? MoyasarError {
+                throw error
+            }
+            
             throw MoyasarError.unexpectedError("Request failed: \(error.localizedDescription)")
         }
     }

--- a/Sdk/MoyasarSdk/Services/PaymentServices/PaymentServices.swift
+++ b/Sdk/MoyasarSdk/Services/PaymentServices/PaymentServices.swift
@@ -71,11 +71,9 @@ final public class PaymentService {
             }
             
             return try decoder.decode(T.self, from: data)
+        } catch let error as MoyasarError {
+            throw error
         } catch {
-            if let moyasarError = error as? MoyasarError {
-                throw error
-            }
-            
             throw MoyasarError.unexpectedError("Request failed: \(error.localizedDescription)")
         }
     }

--- a/SwiftUiDemo/SwiftUiDemo/ContentView.swift
+++ b/SwiftUiDemo/SwiftUiDemo/ContentView.swift
@@ -4,7 +4,6 @@ import PassKit
 
 // Below is a demo of how to use Moyasar's SDK
 
-fileprivate let applePayHandler = ApplePayPaymentHandler(paymentRequest: paymentRequest)
 fileprivate let token = ApiTokenRequest(
     name: "source.name",
     number: "source.number",
@@ -58,7 +57,7 @@ struct ContentView: View {
         } else if case let .failed(error) = status {
             Text("Whops 🤭")
                 .padding(.bottom, /*@START_MENU_TOKEN@*/10/*@END_MENU_TOKEN@*/)
-            Text("Something went wrong: " + error.localizedDescription)
+            Text("Something went wrong: " + moyasarErrorToString(error))
                 .font(.caption)
         } else if case let .unknown(string) = status {
             Text("Hmmmmm 🤔")
@@ -75,7 +74,7 @@ struct ContentView: View {
                 status = .success(payment)
             } else {
                 if case let .creditCard(source) = payment.source, payment.status == .failed {
-                    status = .failed(PaymentErrorSample.webViewAuthFailed(source.message ?? ""))
+                    status = .unknown(source.message ?? "")
                     print("Payment failed: \(source.message ?? "")")
                 } else {
                     // Handle payment statuses
@@ -87,9 +86,8 @@ struct ContentView: View {
         case let .saveOnlyToken(token):
             status = .successToken(token)
             break;
-        case let .failed( error):
+        case let .failed(error):
             status = .failed(error)
-            break;
         case .canceled:
             status = .reset
             break;
@@ -100,7 +98,45 @@ struct ContentView: View {
     }
     
     func applePayPressed(action: UIAction) {
-        applePayHandler.present()
+        do {
+            let applePayHandler = try ApplePayPaymentHandler(paymentRequest: paymentRequest)
+            applePayHandler.present()
+        } catch {
+            status = .failed(error as! MoyasarError)
+        }
+    }
+    
+    func encloseMoyasarError(_ error: Error) -> MoyasarError {
+        if let moyasarError = error as? MoyasarError {
+            return moyasarError
+        } else {
+            return MoyasarError.unexpectedError(error.localizedDescription)
+        }
+    }
+    
+    func moyasarErrorToString(_ error: MoyasarError) -> String {
+        switch (error) {
+        case let .apiError(apiError):
+            return apiError.message ?? "unspcified api error";
+        case .apiKeyNotSet:
+            return "API Key is not set";
+        case let .authorizationError(intError):
+            return intError;
+        case let .invalidApiKey(intError):
+            return intError;
+        case let .networkError(intError):
+            return intError.localizedDescription;
+        case let .webviewNotConnectedToInternet(payment):
+            return "Webview cannot connect to internet, payment id: \(payment.id)";
+        case let .webviewTimedOut(payment):
+            return "Webview timed out, payment id: \(payment.id)";
+        case let .webviewUnexpectedError(payment, webviewError):
+            return "Webview error, payment id: \(payment.id). Error: \(webviewError.localizedDescription)";
+        case let.unexpectedError(intError):
+            return intError
+        default:
+            return "Unexpected error"
+        }
     }
 }
 

--- a/SwiftUiDemo/SwiftUiDemo/Custom View/CustomView.swift
+++ b/SwiftUiDemo/SwiftUiDemo/Custom View/CustomView.swift
@@ -6,10 +6,9 @@
 //
 
 import SwiftUI
+import MoyasarSdk
 
 // Below is a basic demo of how to use Moyasar's APIs with your own UI implementation (You shouldn't implement your UI and logic exactly like below)
-
-fileprivate let applePayHandler = ApplePayPaymentHandler(paymentRequest: paymentRequest)
 
 struct CustomView: View {
     
@@ -80,7 +79,20 @@ struct CustomView: View {
     }
     
     func applePayPressed(action: UIAction) {
-        applePayHandler.present()
+        do {
+            let applePayHandler = try ApplePayPaymentHandler(paymentRequest: paymentRequest)
+            applePayHandler.present()
+        } catch {
+            viewModel.appStatus = .failed(encloseMoyasarError(error))
+        }
+    }
+    
+    func encloseMoyasarError(_ error: Error) -> MoyasarError {
+        if let moyasarError = error as? MoyasarError {
+            return moyasarError
+        } else {
+            return MoyasarError.unexpectedError(error.localizedDescription)
+        }
     }
 }
 

--- a/SwiftUiDemo/SwiftUiDemo/Custom View/CustomViewModel.swift
+++ b/SwiftUiDemo/SwiftUiDemo/Custom View/CustomViewModel.swift
@@ -98,7 +98,7 @@ class CustomViewModel: ObservableObject {
                 appStatus = .success(currentPayment!)
             } else {
                 if case let .creditCard(source) = currentPayment!.source, currentPayment!.status == .failed {
-                    appStatus = .failed(PaymentErrorSample.webViewAuthFailed(source.message ?? ""))
+                    appStatus = .unknown(source.message ?? "")
                     print("Payment failed: \(source.message ?? "")")
                 } else {
                     // Handle payment statuses
@@ -109,7 +109,7 @@ class CustomViewModel: ObservableObject {
             break
         case .failed(let error):
             // Handle error
-            appStatus = .failed(error)
+            appStatus = .unknown(error.localizedDescription)
             break
         }
     }

--- a/SwiftUiDemo/SwiftUiDemo/SwiftUiDemoApp.swift
+++ b/SwiftUiDemo/SwiftUiDemo/SwiftUiDemoApp.swift
@@ -17,12 +17,13 @@ import MoyasarSdk
 /// 10 JPY = 10 JPY (Japanese Yen does not have fractions)
 let paymentRequest = PaymentRequest(
     apiKey: "pk_test_vcFUHJDBwiyRu4Bd3hFuPpTnRPY4gp2ssYdNJMY3",
+    baseUrl: "https://apimig.moyasar.com",
     amount: 100,
     currency: "SAR",
     description: "Testing iOS SDK",
     metadata: ["order_id": "ios_order_3214124"],
     manual: false,
-    createSaveOnlyToken: false//,
+    createSaveOnlyToken: false
    // allowedNetworks: [.visa, .mastercard]
 )
 
@@ -40,10 +41,7 @@ enum MyAppStatus {
     case reset
     case success(ApiPayment)
     case successToken(ApiToken)
-    case failed(Error)
+    case failed(MoyasarError)
     case unknown(String)
 }
 
-enum PaymentErrorSample: Error {
-    case webViewAuthFailed(String)
-}

--- a/SwiftUiDemo/SwiftUiDemo/SwiftUiDemoApp.swift
+++ b/SwiftUiDemo/SwiftUiDemo/SwiftUiDemoApp.swift
@@ -17,7 +17,6 @@ import MoyasarSdk
 /// 10 JPY = 10 JPY (Japanese Yen does not have fractions)
 let paymentRequest = PaymentRequest(
     apiKey: "pk_test_vcFUHJDBwiyRu4Bd3hFuPpTnRPY4gp2ssYdNJMY3",
-    baseUrl: "https://apimig.moyasar.com",
     amount: 100,
     currency: "SAR",
     description: "Testing iOS SDK",


### PR DESCRIPTION
## Note about example:

- When a payment is created, its status can be `paid` or `failed` so we must check the status before assuming the payment is successful. See my changes to the Apple Pay example.
- Change error handling for initializing services and views
    - The `handleError` in `CreditCardViewModel` loses the actual error which we are not able to handle so I have removed the encapsulating error.
- Add space between month and year, e.g. `08 / 28`
- Make request in payment service catches all errors and enclose them inside MoyasarError which loses the original error, I have fixed this. Errors now should show the actual error (see the screenshot).
- To better handle errors while initializing the services, it is better to create the service class only where it is needed and avoid globals, see changes to `ContentView`.


## Add new fields to Credit Card and Apple Pay Respomse

We need to add the following fields to both Credit Card and Apple Pay sources:
- issuerName (issuer_name)
- issuerCountry (issuer_country)
- issuerCardType (issuer_card_type)
- isserCardCategory (issuer_card_category)

All these fields are of type `string` and they are optional (can be empty) and also might be missing from response as old merchant accounts does not have these fields enabled.
